### PR TITLE
add `react-help-create` project

### DIFF
--- a/README.md
+++ b/README.md
@@ -973,3 +973,4 @@ A curated list of awesome JavaScript frameworks, libraries and software.
 * [rdio/jsfmt](https://github.com/rdio/jsfmt) - For formatting, searching, and rewriting JavaScript.
 * [nytimes/ice](https://github.com/nytimes/ice) - track changes with javascript
 * [Jianru-Lin/lambda-view](https://github.com/Jianru-Lin/lambda-view) - A New Tool for Reading JavaScript Code since 2017
+* [React Help Create](https://github.com/Omar-Belghaouti/react-help-create) - This command line helps you create components, pages and even redux implementation for your react project


### PR DESCRIPTION
This PR is dedicated to add `react-help-create` project to the list of projects.