### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -973,3 +973,5 @@ A curated list of awesome JavaScript frameworks, libraries and software.
 * [rdio/jsfmt](https://github.com/rdio/jsfmt) - For formatting, searching, and rewriting JavaScript.
 * [nytimes/ice](https://github.com/nytimes/ice) - track changes with javascript
 * [Jianru-Lin/lambda-view](https://github.com/Jianru-Lin/lambda-view) - A New Tool for Reading JavaScript Code since 2017
+* [jspreadsheet/ce](https://github.com/jspreadsheet/ce) - Jspreadsheet is a lightweight vanilla javascript plugin to create amazing web-based online interactive tables and spreadsheets compatible with other spreadsheet software.
+


### PR DESCRIPTION
Add plugin jspreadsheet. Jspreadsheetis a lightweight vanilla javascript plugin to create amazing web-based online interactive tables and spreadsheets compatible with other spreadsheet software. You can create an online spreadsheet table from a JS array, JSON, CSV or XSLX files. You can copy from excel and paste straight to your online spreadsheet and vice versa. It is very easy to integrate any third party javascript plugins to create your own custom columns, custom editors, and customize any feature into your application. Jspreadsheet has plenty of different input options through its native column types to cover the most common web-based application requirements. It is a complete solution for web data management. Create amazing online spreadsheets with Jspreadsheet. 