### PR TITLE
updating EmbedchainJS framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -733,3 +733,4 @@ A curated list of awesome JavaScript frameworks, libraries and software.
 * [jakejs/jake](https://github.com/jakejs/jake) - JavaScript build tool, similar to Make or Rake. Built to work with Node.js.
 * [open-wc/open-wc](https://github.com/open-wc/open-wc) - Open Web Components: guides, tools and libraries for developing web components.
 * [gcanti/tcomb](https://github.com/gcanti/tcomb) - Type checking and DDD for JavaScript
+* [embedchain/embedchainjs](https://github.com/embedchain/embedchainjs) - Framework to easily create LLM powered bots over any dataset


### PR DESCRIPTION
Adding Embedchain (JS version) framework to the list.

Helps create ChatGPT like bots, easily and over your own dataset.
Repo: https://github.com/embedchain/embedchainjs