### PR TITLE
Removed Atom editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ A curated list of awesome JavaScript frameworks, libraries and software.
 * [webpack/webpack](https://github.com/webpack/webpack) - A bundler for javascript and friends. Packs many modules into a few bundled assets. Code Splitting allows for loading parts of the application on demand. Through "loaders", modules can be CommonJs, AMD, ES6 modules, CSS, Images, JSON, Coffeescript, LESS, ... and your custom stuff.
 * [chartjs/Chart.js](https://github.com/chartjs/Chart.js) - Simple HTML5 Charts using the <canvas> tag
 * [leonardomso/33-js-concepts](https://github.com/leonardomso/33-js-concepts) - 📜 33 JavaScript concepts every developer should know.
-* [atom/atom](https://github.com/atom/atom) - :atom: The hackable text editor
 * [lodash/lodash](https://github.com/lodash/lodash) - A modern JavaScript utility library delivering modularity, performance, & extras.
 * [jquery/jquery](https://github.com/jquery/jquery) - jQuery JavaScript Library
 * [azl397985856/leetcode](https://github.com/azl397985856/leetcode) - LeetCode Solutions: A Record of My Problem Solving Journey.( leetcode题解，记录自己的leetcode解题之路。)


### PR DESCRIPTION
Removed Atom editor, as the project was sunset by GitHub on 12/22
https://github.blog/2022-06-08-sunsetting-atom/